### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-compact_str = { version = "0.3", default-features = false, features = [ "serde" ] }
+compact_str = { version = "0.4", default-features = false, features = [ "serde" ] }
 serde = { version = "1", default-features = false, features = [ "derive", "alloc", "rc" ] }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1,10 +1,10 @@
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NetworkPacket {
     id: i64,
-    r#type: CompactStr,
+    r#type: CompactString,
     body: Vec<u8>,
     payload_transfer_info: Vec<u8>,
     payload_size: i64,


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning